### PR TITLE
added check for img visibility

### DIFF
--- a/riloadr.jquery.js
+++ b/riloadr.jquery.js
@@ -716,7 +716,7 @@
     function isInViewport(img, threshold) {
         var $img = $(img);
         return !isBelowTheFold($img, threshold) && !isAboveTheTop($img, threshold) &&
-            !isRightOfFold($img, threshold) && !isLeftOfBegin($img, threshold);
+            !isRightOfFold($img, threshold) && !isLeftOfBegin($img, threshold) && isVisible($img);
     }
 
 
@@ -737,6 +737,10 @@
 
     function isLeftOfBegin($img, threshold) {
         return $win[SCROLLLEFT]() >= $img[OFFSET]()[LEFT] + threshold + $img[WIDTH]();
+    }
+
+    function isVisible($img) {
+        return $img.is(':visible');
     }
 
 


### PR DESCRIPTION
Here's a sketch in jQuery for checking visibility.  

Use case:  The image is in a div that is toggled (ie click to show image).  

```
<a id="toggle">toggle</a>
<div id="hidden-img" style="display: none">
  <img class="lazyload" data-src="some-image.jpg" />
</div>

<script>
var lazy = new Riloadr(
  name: 'lazyload',
  defer: {mode: 'invisible'},
  breakpoints: [{name: 'all', minWidth: 0}]
);

$('#toggle').click(function (e) {
  $('#hidden-img').toggle();
  lazy.riload();
}
</script>
```
